### PR TITLE
Locify input csv fromUri column in excelerator

### DIFF
--- a/excelerator/imports/api/methods-init.js
+++ b/excelerator/imports/api/methods-init.js
@@ -140,6 +140,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
                     title: "MeshBlock",
                     uri: "http://linked.data.gov.au/def/asgs#MeshBlock",
+                    prefix: "http://linked.data.gov.au/dataset/asgs2016/meshblock/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1",
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
@@ -152,6 +153,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
                     title: "SA1",
                     uri: "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1",
+                    prefix: "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel1/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
@@ -162,6 +164,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
                     title: "SA2",
                     uri: "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
+                    prefix: "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel2/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
@@ -171,6 +174,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
                     title: "SA3",
                     uri: "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
+                    prefix: "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel3/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
                         "http://linked.data.gov.au/def/asgs#StateOrTerritory"
@@ -179,6 +183,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
                     title: "SA4",
                     uri: "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
+                    prefix: "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel4/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StateOrTerritory"
                     ],
@@ -186,6 +191,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
                     title: "StateOrTerritory",
                     uri: "http://linked.data.gov.au/def/asgs#StateOrTerritory",
+                    prefix: "http://linked.data.gov.au/dataset/asgs2016/stateorterritory/",
                 }];
 
                 var asgs11 = asgs16.map(x => Object.assign({}, x, { datasetUri: "http://linked.data.gov.au/dataset/asgs2011" }));
@@ -194,6 +200,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/geofabric",
                     title: "Contracted Catchment",
                     uri: "http://linked.data.gov.au/def/geofabric#ContractedCatchment",
+                    prefix: "http://linked.data.gov.au/dataset/geofabric/contractedcatchment/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/geofabric#RiverRegion",
                         "http://linked.data.gov.au/def/geofabric#DrainageDivision"
@@ -203,6 +210,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/geofabric",
                     title: "River Region",
                     uri: "http://linked.data.gov.au/def/geofabric#RiverRegion",
+                    prefix: "http://linked.data.gov.au/dataset/geofabric/riverregion/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/geofabric#DrainageDivision"
                     ],
@@ -210,12 +218,14 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/geofabric",
                     title: "Drainage Division",
                     uri: "http://linked.data.gov.au/def/geofabric#DrainageDivision",
+                    prefix: "http://linked.data.gov.au/dataset/geofabric/drainagedivision/"
                 }];
 
                 var gnafCurrent = [{
                     datasetUri: "http://linked.data.gov.au/dataset/gnaf",
                     title: "Address",
                     uri: "http://linked.data.gov.au/def/gnaf#Address",
+                    prefix: "http://linked.data.gov.au/dataset/gnaf/address/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/gnaf#StreetLocality",
                         "http://linked.data.gov.au/def/gnaf#Locality"
@@ -225,6 +235,7 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/gnaf",
                     title: "Street Locality",
                     uri: "http://linked.data.gov.au/def/gnaf#StreetLocality",
+                    prefix: "http://linked.data.gov.au/dataset/gnaf/streetLocality/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/gnaf#Locality"
                     ],
@@ -232,9 +243,35 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/gnaf",
                     title: "Locality",
                     uri: "http://linked.data.gov.au/def/gnaf#Locality",
+                    prefix: "http://linked.data.gov.au/dataset/gnaf/locality/"
+                }];
+
+                var gnaf16 = [{
+                    datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05",
+                    title: "Address",
+                    uri: "http://linked.data.gov.au/def/gnaf#Address",
+                    prefix: "http://linked.data.gov.au/dataset/gnaf-2016-05/address/",
+                    withinTypes: [
+                        "http://linked.data.gov.au/def/gnaf#StreetLocality",
+                        "http://linked.data.gov.au/def/gnaf#Locality"
+                    ],
+                    baseType: true,
+                }, {
+                    datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05",
+                    title: "Street Locality",
+                    uri: "http://linked.data.gov.au/def/gnaf#StreetLocality",
+                    prefix: "http://linked.data.gov.au/dataset/gnaf-2016-05/streetLocality/",
+                    withinTypes: [
+                        "http://linked.data.gov.au/def/gnaf#Locality"
+                    ],
+                }, {
+                    datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05",
+                    title: "Locality",
+                    uri: "http://linked.data.gov.au/def/gnaf#Locality",
+                    prefix: "http://linked.data.gov.au/dataset/gnaf-2016-05/locality/"
                 }]
 
-                var gnaf16 = gnafCurrent.map(x => Object.assign({}, x, { datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05" }));
+                //var gnaf16 = gnafCurrent.map(x => Object.assign({}, x, { datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05" }));
 
                 var all = [].concat.apply([], [asgs16, asgs11, geofabric, gnafCurrent, gnaf16]);
 

--- a/excelerator/imports/api/methods-init.js
+++ b/excelerator/imports/api/methods-init.js
@@ -135,12 +135,12 @@ WHERE {
 
                 console.log("Refreshing Datatypes List")
 
-
+                var currDatasetUri = "http://linked.data.gov.au/dataset/asgs2016";
                 var asgs16 = [{
-                    datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
+                    datasetUri: currDatasetUri,
                     title: "MeshBlock",
                     uri: "http://linked.data.gov.au/def/asgs#MeshBlock",
-                    prefix: "http://linked.data.gov.au/dataset/asgs2016/meshblock/",
+                    prefix: currDatasetUri + "/meshblock/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1",
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
@@ -150,10 +150,10 @@ WHERE {
                     ],
                     baseType: true
                 }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
+                    datasetUri: currDatasetUri,
                     title: "SA1",
                     uri: "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1",
-                    prefix: "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel1/",
+                    prefix: currDatasetUri + "/statisticalarealevel1/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
@@ -161,46 +161,51 @@ WHERE {
                         "http://linked.data.gov.au/def/asgs#StateOrTerritory"
                     ],
                 }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
+                    datasetUri: currDatasetUri,
                     title: "SA2",
                     uri: "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2",
-                    prefix: "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel2/",
+                    prefix: currDatasetUri + "/statisticalarealevel2/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
                         "http://linked.data.gov.au/def/asgs#StateOrTerritory"
                     ],
                 }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
+                    datasetUri: currDatasetUri,
                     title: "SA3",
                     uri: "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3",
-                    prefix: "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel3/",
+                    prefix: currDatasetUri + "/statisticalarealevel3/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
                         "http://linked.data.gov.au/def/asgs#StateOrTerritory"
                     ],
                 }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
+                    datasetUri: currDatasetUri,
                     title: "SA4",
                     uri: "http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4",
-                    prefix: "http://linked.data.gov.au/dataset/asgs2016/statisticalarealevel4/",
+                    prefix: currDatasetUri + "/statisticalarealevel4/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/asgs#StateOrTerritory"
                     ],
                 }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/asgs2016",
+                    datasetUri: currDatasetUri,
                     title: "StateOrTerritory",
                     uri: "http://linked.data.gov.au/def/asgs#StateOrTerritory",
-                    prefix: "http://linked.data.gov.au/dataset/asgs2016/stateorterritory/",
+                    prefix: currDatasetUri + "/stateorterritory/",
                 }];
 
-                var asgs11 = asgs16.map(x => Object.assign({}, x, { datasetUri: "http://linked.data.gov.au/dataset/asgs2011" }));
+                currDatasetUri = "http://linked.data.gov.au/dataset/asgs2011";
+                var asgs11 = asgs16.map(x => Object.assign({}, x, { 
+                    datasetUri: currDatasetUri,
+                    prefix:  `${currDatasetUri}/${x.prefix.split('/').slice(-2)[0]}/`
+                }));
 
+                currDatasetUri = "http://linked.data.gov.au/dataset/geofabric";
                 var geofabric = [{
-                    datasetUri: "http://linked.data.gov.au/dataset/geofabric",
+                    datasetUri: currDatasetUri,
                     title: "Contracted Catchment",
                     uri: "http://linked.data.gov.au/def/geofabric#ContractedCatchment",
-                    prefix: "http://linked.data.gov.au/dataset/geofabric/contractedcatchment/",
+                    prefix: currDatasetUri + "/contractedcatchment/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/geofabric#RiverRegion",
                         "http://linked.data.gov.au/def/geofabric#DrainageDivision"
@@ -210,68 +215,48 @@ WHERE {
                     datasetUri: "http://linked.data.gov.au/dataset/geofabric",
                     title: "River Region",
                     uri: "http://linked.data.gov.au/def/geofabric#RiverRegion",
-                    prefix: "http://linked.data.gov.au/dataset/geofabric/riverregion/",
+                    prefix: currDatasetUri + "/riverregion/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/geofabric#DrainageDivision"
                     ],
                 }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/geofabric",
+                    datasetUri: currDatasetUri,
                     title: "Drainage Division",
                     uri: "http://linked.data.gov.au/def/geofabric#DrainageDivision",
-                    prefix: "http://linked.data.gov.au/dataset/geofabric/drainagedivision/"
+                    prefix: currDatasetUri + "/drainagedivision/"
                 }];
 
+                currDatasetUri = "http://linked.data.gov.au/dataset/gnaf";
                 var gnafCurrent = [{
-                    datasetUri: "http://linked.data.gov.au/dataset/gnaf",
+                    datasetUri: currDatasetUri,
                     title: "Address",
                     uri: "http://linked.data.gov.au/def/gnaf#Address",
-                    prefix: "http://linked.data.gov.au/dataset/gnaf/address/",
+                    prefix: currDatasetUri + "/address/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/gnaf#StreetLocality",
                         "http://linked.data.gov.au/def/gnaf#Locality"
                     ],
                     baseType: true,
                 }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/gnaf",
+                    datasetUri: currDatasetUri,
                     title: "Street Locality",
                     uri: "http://linked.data.gov.au/def/gnaf#StreetLocality",
-                    prefix: "http://linked.data.gov.au/dataset/gnaf/streetLocality/",
+                    prefix: currDatasetUri + "/streetLocality/",
                     withinTypes: [
                         "http://linked.data.gov.au/def/gnaf#Locality"
                     ],
                 }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/gnaf",
+                    datasetUri: currDatasetUri,
                     title: "Locality",
                     uri: "http://linked.data.gov.au/def/gnaf#Locality",
-                    prefix: "http://linked.data.gov.au/dataset/gnaf/locality/"
+                    prefix: currDatasetUri + "/locality/"
                 }];
 
-                var gnaf16 = [{
-                    datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05",
-                    title: "Address",
-                    uri: "http://linked.data.gov.au/def/gnaf#Address",
-                    prefix: "http://linked.data.gov.au/dataset/gnaf-2016-05/address/",
-                    withinTypes: [
-                        "http://linked.data.gov.au/def/gnaf#StreetLocality",
-                        "http://linked.data.gov.au/def/gnaf#Locality"
-                    ],
-                    baseType: true,
-                }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05",
-                    title: "Street Locality",
-                    uri: "http://linked.data.gov.au/def/gnaf#StreetLocality",
-                    prefix: "http://linked.data.gov.au/dataset/gnaf-2016-05/streetLocality/",
-                    withinTypes: [
-                        "http://linked.data.gov.au/def/gnaf#Locality"
-                    ],
-                }, {
-                    datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05",
-                    title: "Locality",
-                    uri: "http://linked.data.gov.au/def/gnaf#Locality",
-                    prefix: "http://linked.data.gov.au/dataset/gnaf-2016-05/locality/"
-                }]
-
-                //var gnaf16 = gnafCurrent.map(x => Object.assign({}, x, { datasetUri: "http://linked.data.gov.au/dataset/gnaf-2016-05" }));
+                currDatasetUri = "http://linked.data.gov.au/dataset/gnaf-2016-05";
+                var gnaf16 = gnafCurrent.map(x => Object.assign({}, x, { 
+                    datasetUri: currDatasetUri,
+                    prefix:  `${currDatasetUri}/${x.prefix.split('/').slice(-2)[0]}/`
+                }));
 
                 var all = [].concat.apply([], [asgs16, asgs11, geofabric, gnafCurrent, gnaf16]);
 

--- a/excelerator/imports/convert.js
+++ b/excelerator/imports/convert.js
@@ -151,6 +151,17 @@ export function processData(data, job, outputStream) {
             if (!fromUri)
                 throw new Meteor.Error(`Undefined uri in row ${i}`);
 
+            //check if fromUri is a URI, else, turn it into a URI based on inputUriType
+            console.log("Classtypeuri: " + jobData.from.classTypeUri);
+            console.log("datasetUri: " + jobData.from.datasetUri);
+            if (!fromUri.startsWith("http")) {
+               //get prefix from DataType and append fromUri value
+               fromUri = inputType.prefix + fromUri;               
+            }
+
+            if (fromUri.indexOf(inputType.datasetUri) == -1)
+                throw new Meteor.Error(`Input data in row ${i} ${fromUri} doesn't appear to be part of the designated FROM dataset ${inputType.datasetUri}`);
+
             // The next "if" is totally a hack, URI should not be dependant on their parent URI
             // Ideally check if the statement belongs to the dataset using the graph relationships. It means another query
             // which may or may not be worth it?

--- a/excelerator/imports/convert.js
+++ b/excelerator/imports/convert.js
@@ -157,9 +157,6 @@ export function processData(data, job, outputStream) {
                fromUri = inputType.prefix + fromUri;               
             }
 
-            if (fromUri.indexOf(inputType.datasetUri) == -1)
-                throw new Meteor.Error(`Input data in row ${i} ${fromUri} doesn't appear to be part of the designated FROM dataset ${inputType.datasetUri}`);
-
             // The next "if" is totally a hack, URI should not be dependant on their parent URI
             // Ideally check if the statement belongs to the dataset using the graph relationships. It means another query
             // which may or may not be worth it?

--- a/excelerator/imports/convert.js
+++ b/excelerator/imports/convert.js
@@ -152,8 +152,6 @@ export function processData(data, job, outputStream) {
                 throw new Meteor.Error(`Undefined uri in row ${i}`);
 
             //check if fromUri is a URI, else, turn it into a URI based on inputUriType
-            console.log("Classtypeuri: " + jobData.from.classTypeUri);
-            console.log("datasetUri: " + jobData.from.datasetUri);
             if (!fromUri.startsWith("http")) {
                //get prefix from DataType and append fromUri value
                fromUri = inputType.prefix + fromUri;               


### PR DESCRIPTION
This PR features enhancements to enable users to use a CSV file that has location codes as input rather than Loc-I URIs. 

Often source data will have the location codes (i.e. ASGS 2016 MeshBlock codes) and values for that particular dataset. Currently users have to manually convert the values in the column with location codes to Loc-I URIs (e.g. from `50055290000` to `http://linked.data.gov.au/dataset/asgs2016/meshblock/50055290000`). This is a barrier as users may not know how to manually do the string conversion.. but they should know which location type it is. So users selecting which dataset and datatype the location code are from the dropdown box in the UI is a more user-friendly way to go. 

This PR provides code that will prepend the Loc-I datatype prefix to the location code, so excelerator can map location code to Loc-I URI based on the prefixes for each dataset and dataset type. 

Related to https://github.com/CSIRO-enviro-informatics/loci-excelerator/issues/29
