### PR TITLE
update query for datasets from cache

### DIFF
--- a/excelerator/imports/api/methods-init.js
+++ b/excelerator/imports/api/methods-init.js
@@ -22,13 +22,23 @@ WHERE {
 }`;
 
             var datasetQuery =
-                `PREFIX void: <http://rdfs.org/ns/void#>
+                `
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX loci: <http://linked.data.gov.au/def/loci#>
-SELECT * 
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?dataset ?pred ?obj
 WHERE {
-    ?dataset a loci:Dataset .
-    ?dataset ?pred ?obj
-}`;
+    {
+        ?dataset a dcat:Dataset .
+        ?dataset ?pred ?obj
+    }
+    UNION
+    {
+        ?dataset a loci:Dataset .
+        ?dataset ?pred ?obj
+    }
+}
+`;
 
 
             try {


### PR DESCRIPTION
The new cache features the use of dcat:Dataset as standard description for datasets in addition to loci:Dataset. This PR updates the init script to include these so that Datasets are not left out of the listing.